### PR TITLE
Potential fix for code scanning alert no. 10: Database query built from user-controlled sources

### DIFF
--- a/controllers/registerController.js
+++ b/controllers/registerController.js
@@ -72,7 +72,7 @@ setEmailAddressUnconfirmed = (user) => {
 
 exports.resendEmailConfirmationLink = (req, res) => {
   //Find users ID
-  User.findOne({ EmailAddress: req.body.email }).exec(async (err, user) => {
+  User.findOne({ EmailAddress: { $eq: req.body.email } }).exec(async (err, user) => {
     if (err) {
       return res.status(500).send({ message: err });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/dazstaffs/MyCV_API_v2/security/code-scanning/10](https://github.com/dazstaffs/MyCV_API_v2/security/code-scanning/10)

To fix the issue, we need to ensure that the user-provided input (`req.body.email`) is interpreted as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator, which forces the query to treat the input as a literal value. Alternatively, we could validate the input to ensure it is a string before using it in the query.

The best approach here is to use the `$eq` operator, as it directly addresses the vulnerability without requiring additional validation logic. This change will ensure that the query is safe from NoSQL injection attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
