### PR TITLE
Potential fix for code scanning alert no. 53: Exception text reinterpreted as HTML

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -81,7 +81,10 @@ exports.setPassword = async (req, res) => {
   });
 
   User.findById(userID, function (err, user) {
-    if (err) res.send(err);
+    if (err) {
+      console.error("Error finding user:", err);
+      return res.status(500).send({ message: "An error occurred while processing your request." });
+    }
     user.Password = newPassword;
     user.save(async function (err) {
       if (err) res.json(err);


### PR DESCRIPTION
Potential fix for [https://github.com/dazstaffs/MyCV_API_v2/security/code-scanning/53](https://github.com/dazstaffs/MyCV_API_v2/security/code-scanning/53)

To fix the issue, the `err` object should be sanitized or escaped before being sent in the HTTP response. A safer approach is to avoid sending the raw error object to the client altogether. Instead, send a generic error message to the client and log the detailed error on the server for debugging purposes. This ensures that no sensitive or user-controlled data is exposed in the response.

The changes involve:
1. Replacing `res.send(err)` with a generic error message.
2. Logging the `err` object on the server for debugging purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
