### PR TITLE
Potential fix for code scanning alert no. 9: Database query built from user-controlled sources

### DIFF
--- a/controllers/registerController.js
+++ b/controllers/registerController.js
@@ -12,7 +12,7 @@ const County = require("../models/countyModel");
 
 exports.checkDuplicateUsername = (req, res, next) => {
   UserCredential.findOne({
-    EmailAddress: req.body.emailAddress,
+    EmailAddress: { $eq: req.body.emailAddress },
   }).exec((err, userCredential) => {
     if (err) {
       res.status(500).send({ message: err });


### PR DESCRIPTION
Potential fix for [https://github.com/dazstaffs/MyCV_API_v2/security/code-scanning/9](https://github.com/dazstaffs/MyCV_API_v2/security/code-scanning/9)

To fix this problem, we should ensure that the user-provided value is always interpreted as a literal value and not as a query object. The best way to do this in MongoDB/Mongoose is to use the `$eq` operator in the query, i.e., `{ EmailAddress: { $eq: req.body.emailAddress } }`. This ensures that even if the user sends an object, it will be treated as a literal value, not as a query operator. The change should be made in the `checkDuplicateUsername` function, specifically on line 14, in the file `controllers/registerController.js`. No new imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
